### PR TITLE
Clear #columnTypeCache when stepping to a new row.

### DIFF
--- a/src/statement.ts
+++ b/src/statement.ts
@@ -357,6 +357,7 @@ export class PreparedStatement {
    */
   step(): Row | undefined {
     if (sqlite3_step(this.#db.unsafeRawHandle, this.#handle) === SQLITE3_ROW) {
+      this.#colTypeCache.clear();
       return this.row;
     }
   }


### PR DESCRIPTION
The SQLite types for the columns can differ between rows.

This can happen for instance on column types that can be NULL, or when using SQLite's dynamic typing.