### PR TITLE
v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # deno_sqlite
 
 [![Tags](https://img.shields.io/github/release/denodrivers/sqlite3)](https://github.com/denodrivers/sqlite3/releases)
-[![Doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/sqlite3@0.5.3/mod.ts)
+[![Doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/sqlite3@0.6.0/mod.ts)
 [![Checks](https://github.com/denodrivers/sqlite3/actions/workflows/ci.yml/badge.svg)](https://github.com/denodrivers/sqlite3/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/denodrivers/sqlite3)](https://github.com/denodrivers/sqlite3/blob/master/LICENSE)
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/DjDeveloperr)
@@ -11,11 +11,11 @@ Fastest & correct JavaScript bindings to SQLite3 C API, using Deno FFI.
 ## Example
 
 ```ts
-import { Database } from "https://deno.land/x/sqlite3@0.5.3/mod.ts";
+import { Database } from "https://deno.land/x/sqlite3@0.6.0/mod.ts";
 
 const db = new Database("test.db");
 
-const [version] = db.prepare("select sqlite_version()").get<[string]>()!;
+const [version] = db.prepare("select sqlite_version()").value<[string]>()!;
 console.log(version);
 
 db.close();
@@ -47,7 +47,7 @@ See [doc.md](https://github.com/denodrivers/sqlite3/blob/main/doc.md) for
 documentation.
 
 Check out the complete API reference
-[here](https://doc.deno.land/https://deno.land/x/sqlite3@0.5.3/mod.ts).
+[here](https://doc.deno.land/https://deno.land/x/sqlite3@0.6.0/mod.ts).
 
 ## Native Library
 

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -430,7 +430,7 @@ try {
     lib = Deno.dlopen(customPath || "sqlite3", symbols).symbols;
   } else {
     const url =
-      "https://github.com/denodrivers/sqlite3/releases/download/v0.5.3/";
+      "https://github.com/denodrivers/sqlite3/releases/download/v0.6.0/";
     lib = (await prepare({
       name: "sqlite3",
       urls: {


### PR DESCRIPTION
## Changelog

- fix: keep reference to buffers before passing their pointers (#59)
- feat!: add `Statement#value` which returns only first row as array and changed `Statement#get` to return row as object instead (previously it returned as array which was confusing (See #58) (#60)

This release includes breaking changes to `Statement#get` method. For the old behavior of get method, use `value` instead.
