### PR TITLE
Fix #73.

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -267,6 +267,18 @@ Deno.test("sqlite", async (t) => {
     assertEquals(double, null);
   });
 
+  await t.step("empty string on not null column", () => {
+    const ldb = new Database(":memory:");
+    try {
+      ldb.exec("create table foo ( name text not null )");
+      ldb.exec("insert into foo (name) values (?)", "");
+      const s = ldb.prepare("select * from foo").value<string[]>();
+      assertEquals(s, [""]);
+    } finally {
+      ldb.close();
+    }
+  });
+
   await t.step("create blob table", () => {
     db.exec(`
       create table blobs (

--- a/test/test.ts
+++ b/test/test.ts
@@ -268,15 +268,10 @@ Deno.test("sqlite", async (t) => {
   });
 
   await t.step("empty string on not null column", () => {
-    const ldb = new Database(":memory:");
-    try {
-      ldb.exec("create table foo ( name text not null )");
-      ldb.exec("insert into foo (name) values (?)", "");
-      const s = ldb.prepare("select * from foo").value<string[]>();
-      assertEquals(s, [""]);
-    } finally {
-      ldb.close();
-    }
+    db.exec(`create table empty_string_not_null ( name text not null )`);
+    db.exec("insert into empty_string_not_null (name) values (?)", "");
+    const s = db.prepare("select * from empty_string_not_null").value<string[]>();
+    assertEquals(s, [""]);
   });
 
   await t.step("create blob table", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -270,7 +270,9 @@ Deno.test("sqlite", async (t) => {
   await t.step("empty string on not null column", () => {
     db.exec(`create table empty_string_not_null ( name text not null )`);
     db.exec("insert into empty_string_not_null (name) values (?)", "");
-    const s = db.prepare("select * from empty_string_not_null").value<string[]>();
+    const s = db.prepare("select * from empty_string_not_null").value<
+      string[]
+    >();
     assertEquals(s, [""]);
   });
 


### PR DESCRIPTION
Empty string is encoded as empty buffer in Deno. And as of right now (Deno 1.29.1), ffi layer converts it to NULL pointer, which causes sqlite3_bind_text to bind the NULL value instead of an empty string. As a workaround let's use a special non-empty buffer, but specify zero length.