### PR TITLE
`ubuntu-latest` -> `ubuntu-20.04` when building `libsqlite3.so`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        
+        os: [ubuntu-20.04, windows-latest, macos-latest]
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -57,7 +57,7 @@ jobs:
         run: deno task build-sqlite-win
 
       - name: Set DENO_SQLITE_PATH (linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: echo "DENO_SQLITE_PATH=$(pwd)/build/libsqlite3.so" >> $GITHUB_ENV
 
       - name: Set DENO_SQLITE_PATH (macos)


### PR DESCRIPTION
From https://github.com/denodrivers/sqlite3/issues/80#issuecomment-1416489124 , the current `libsqlite3.so` causes some people to get this type of error:

```
: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ...`
```

This is because dynamic library that are compiled on a computer with a high glibc version can't be ran on computers with a lower glibc version. The `ubuntu-latest` runner (`v22.04`) has glib v2.33, but people who are running ubuntu 18/20 or other linux OS with a lower glibc version can't run it. 

So this PR changes the action to use `ubuntu-20.04`, so it's more compatible with more people. People running `ubuntu-18.04` still won't be able to use it, which sucks, but the `ubuntu-18.04` GH action runner [will be deprecated April 2023](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/).

Another option is a custom Dockerfile that runs a OS with a very low libc version, but that isn't very easy