### PR TITLE
added types to transaction to infer types from passed function

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -35,7 +35,7 @@ export interface DatabaseOpenOptions {
 
 /** Transaction function created using `Database#transaction`. */
 export type Transaction<T extends (...args: any[]) => void> =
-  & ((...args: Parameters<T>) => void)
+  & ((...args: Parameters<T>) => ReturnType<T>)
   & {
     /** BEGIN */
     default: Transaction<T>;
@@ -775,7 +775,7 @@ const wrapTransaction = <T extends (...args: any[]) => void>(
   db: Database,
   { begin, commit, rollback, savepoint, release, rollbackTo }: any,
 ) =>
-  function sqliteTransaction(...args: Parameters<T>): void {
+  function sqliteTransaction(...args: Parameters<T>): ReturnType<T> {
     const { apply } = Function.prototype;
     let before, after, undo;
     if (db.inTransaction) {


### PR DESCRIPTION
Now when passing a function into `db.transaction`, the returned function will infer the argument types from the provided function.

![image](https://user-images.githubusercontent.com/7959437/230790622-a4ddcd44-bc12-48ff-bb12-a2d693a110f7.png)
![image](https://user-images.githubusercontent.com/7959437/230790648-2e81985d-2f66-4f6f-bae5-d670fb23ff95.png)
