### PR TITLE
Detect JSON subtypes and `JSON.parse()` before returning.

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -202,8 +202,10 @@ const row = stmt.value<[string, number]>(...params);
 
 ## SQLite functions that return JSON
 
-When using [SQLite's builtin JSON functions](https://www.sqlite.org/json1.html), `sqlite3` will detect when a value has a "subtype" of JSON. If so, it will attempt to `JSON.parse()` the text value and return the parsed JavaScript object or array.
-
+When using [SQLite's builtin JSON functions](https://www.sqlite.org/json1.html),
+`sqlite3` will detect when a value has a "subtype" of JSON. If so, it will
+attempt to `JSON.parse()` the text value and return the parsed JavaScript object
+or array.
 
 ```ts
 const [list] = db
@@ -218,7 +220,9 @@ const [object] = db
 // object = { name: "Peter" }
 ```
 
-Use the builtin [`json()`](https://www.sqlite.org/json1.html#jmini) SQL function to convert your text values into JSON. 
+Use the builtin [`json()`](https://www.sqlite.org/json1.html#jmini) SQL function
+to convert your text values into JSON.
+
 ## Freeing Prepared Statements
 
 Though the `Statement` object is automatically freed once it is no longer used,

--- a/doc.md
+++ b/doc.md
@@ -330,23 +330,25 @@ stmt.run("baz", "foo");
 
 JavaScript to SQLite type mapping:
 
-| JavaScript type | SQLite type       |
-| --------------- | ----------------- |
-| `null`          | `NULL`            |
-| `undefined`     | `NULL`            |
-| `number`        | `INTEGER`/`FLOAT` |
-| `bigint`        | `INTEGER`         |
-| `string`        | `TEXT`            |
-| `boolean`       | `INTEGER`         |
-| `Date`          | `TEXT` (ISO)      |
-| `Uint8Array`    | `BLOB`            |
+| JavaScript type         | SQLite type                 |
+| ----------------------- | --------------------------- |
+| `null`                  | `NULL`                      |
+| `undefined`             | `NULL`                      |
+| `number`                | `INTEGER`/`FLOAT`           |
+| `bigint`                | `INTEGER`                   |
+| `string`                | `TEXT`                      |
+| `boolean`               | `INTEGER`                   |
+| `Date`                  | `TEXT` (ISO)                |
+| `Uint8Array`            | `BLOB`                      |
+| JSON-serializable value | `TEXT` (`JSON.stringify()`) |
 
 When retrieving rows, the types are mapped back to JavaScript types:
 
-| SQLite type | JavaScript type   |
-| ----------- | ----------------- |
-| `NULL`      | `null`            |
-| `INTEGER`   | `number`/`bigint` |
-| `FLOAT`     | `number`          |
-| `TEXT`      | `string`          |
-| `BLOB`      | `Uint8Array`      |
+| SQLite type              | JavaScript type           |
+| ------------------------ | ------------------------- |
+| `NULL`                   | `null`                    |
+| `INTEGER`                | `number`/`bigint`         |
+| `FLOAT`                  | `number`                  |
+| `TEXT`                   | `string`                  |
+| `TEXT` with JSON subtype | `object` (`JSON.parse()`) |
+| `BLOB`                   | `Uint8Array`              |

--- a/doc.md
+++ b/doc.md
@@ -200,6 +200,25 @@ const row = stmt.value<[string, number]>(...params);
 // row is [string, number] | undefined
 ```
 
+## SQLite functions that return JSON
+
+When using [SQLite's builtin JSON functions](https://www.sqlite.org/json1.html), `sqlite3` will detect when a value has a "subtype" of JSON. If so, it will attempt to `JSON.parse()` the text value and return the parsed JavaScript object or array.
+
+
+```ts
+const [list] = db
+  .prepare("SELECT json_array(1, 2, 3) as list")
+  .value<[number[]]>()!;
+// list = [ 1, 2, 3 ]
+
+const [object] = db
+  .prepare("SELECT json_object('name', 'Peter') as object")
+  .value<[{ name: string }]>()!;
+
+// object = { name: "Peter" }
+```
+
+Use the builtin [`json()`](https://www.sqlite.org/json1.html#jmini) SQL function to convert your text values into JSON. 
 ## Freeing Prepared Statements
 
 Though the `Statement` object is automatically freed once it is no longer used,

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -110,6 +110,13 @@ const symbols = {
     ],
     result: "pointer",
   },
+  sqlite3_column_value: {
+    parameters: [
+      "pointer", // sqlite3_stmt *pStmt
+      "i32", // int iCol
+    ],
+    result: "pointer",
+  },
 
   sqlite3_finalize: {
     parameters: [
@@ -481,6 +488,12 @@ const symbols = {
   },
 
   sqlite3_value_type: {
+    parameters: [
+      "pointer", // sqlite3_value *pVal
+    ],
+    result: "i32",
+  },
+  sqlite3_value_subtype: {
     parameters: [
       "pointer", // sqlite3_value *pVal
     ],

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -52,7 +52,9 @@ export type BindValue =
   | null
   | undefined
   | Date
-  | Uint8Array;
+  | Uint8Array
+  | BindValue[]
+  | { [key: string]: BindValue };
 
 export type BindParameters = BindValue[] | Record<string, BindValue>;
 export type RestBindParameters = BindValue[] | [BindParameters];
@@ -312,7 +314,17 @@ export class Statement {
             ),
           );
         } else {
-          throw new Error(`Value of unsupported type: ${Deno.inspect(param)}`);
+          const cstring = toCString(JSON.stringify(param));
+          this.#bindRefs.add(cstring);
+          unwrap(
+            sqlite3_bind_text(
+              this.#handle,
+              i + 1,
+              cstring,
+              -1,
+              null,
+            ),
+          );
         }
         break;
       }

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -17,6 +17,8 @@ const {
   sqlite3_step,
   sqlite3_column_count,
   sqlite3_column_type,
+  sqlite3_column_value,
+  sqlite3_value_subtype,
   sqlite3_column_text,
   sqlite3_finalize,
   sqlite3_column_int64,
@@ -68,6 +70,9 @@ const statementFinalizer = new FinalizationRegistry(
   },
 );
 
+// https://github.com/sqlite/sqlite/blob/195611d8e6fc0bba559a49e91e6ceb42e4bdd6ba/src/json.c#L125-L126
+const JSON_SUBTYPE = 74;
+
 function getColumn(handle: Deno.PointerValue, i: number, int64: boolean): any {
   const ty = sqlite3_column_type(handle, i);
 
@@ -77,7 +82,17 @@ function getColumn(handle: Deno.PointerValue, i: number, int64: boolean): any {
     case SQLITE_TEXT: {
       const ptr = sqlite3_column_text(handle, i);
       if (ptr === null) return null;
-      return readCstr(ptr, 0);
+      const text = readCstr(ptr, 0);
+      const value = sqlite3_column_value(handle, i);
+      const subtype = sqlite3_value_subtype(value);
+      if (subtype === JSON_SUBTYPE) {
+        try {
+          return JSON.parse(text);
+        } catch (_error) {
+          return text;
+        }
+      }
+      return text;
     }
 
     case SQLITE_INTEGER: {

--- a/test/test.ts
+++ b/test/test.ts
@@ -180,6 +180,16 @@ Deno.test("sqlite", async (t) => {
     }
   });
 
+  await t.step("query json", () => {
+    const row = db
+      .prepare("select json('[1,2,3]'), json_object('name', 'alex'), '{\"no_subtype\": true}'")
+      .values<[number[], {name: string}, string]>()[0];
+
+    assertEquals(row[0], [1, 2, 3]);
+    assertEquals(row[1], {name: "alex"});
+    assertEquals(row[2], '{"no_subtype": true}');
+  });
+
   await t.step("query with string param", () => {
     const row = db.prepare(
       "select * from test where text = ?",

--- a/test/test.ts
+++ b/test/test.ts
@@ -215,6 +215,23 @@ Deno.test("sqlite", async (t) => {
     assertEquals(row[3], new Uint8Array([3, 2, 1]));
     assertEquals(row[4], null);
   });
+  await t.step("query parameters", () => {
+    const row = db.prepare(
+      "select ?, ?, ?, ?, ?",
+    ).values<[number, string, string, string, string]>(
+      1,
+      "alex",
+      new Date("2023-01-01"),
+      [1, 2, 3],
+      { name: "alex" },
+    )[0];
+
+    assertEquals(row[0], 1);
+    assertEquals(row[1], "alex");
+    assertEquals(row[2], "2023-01-01T00:00:00.000Z");
+    assertEquals(row[3], "[1,2,3]");
+    assertEquals(row[4], '{"name":"alex"}');
+  });
 
   await t.step("more than 32-bit int", () => {
     const value = 978307200000;

--- a/test/test.ts
+++ b/test/test.ts
@@ -182,11 +182,13 @@ Deno.test("sqlite", async (t) => {
 
   await t.step("query json", () => {
     const row = db
-      .prepare("select json('[1,2,3]'), json_object('name', 'alex'), '{\"no_subtype\": true}'")
-      .values<[number[], {name: string}, string]>()[0];
+      .prepare(
+        "select json('[1,2,3]'), json_object('name', 'alex'), '{\"no_subtype\": true}'",
+      )
+      .values<[number[], { name: string }, string]>()[0];
 
     assertEquals(row[0], [1, 2, 3]);
-    assertEquals(row[1], {name: "alex"});
+    assertEquals(row[1], { name: "alex" });
     assertEquals(row[2], '{"no_subtype": true}');
   });
 


### PR DESCRIPTION
This PR adds a new potentially backwards-incompatible update: for columns that are the return values of JSON functions, it'll`JSON.parse()` the text value and return list + objects instead of serialized JSON text. 


When using [SQLite's builtin JSON functions](https://www.sqlite.org/json1.html), SQLite will give JSON values a special "subtype" value. We can use this "JSON subtype" to detect if a value is valid JSON. If so, we can parse the text string before returning the values back to the user. 

An example:

```ts
const [list] = db
  .prepare("SELECT json_array(1, 2, 3) as list")
  .value<[number[]]>()!;
// list = [ 1, 2, 3 ]

const [object] = db
  .prepare("SELECT json_object('name', 'Peter') as object")
  .value<[{ name: string }]>()!;

// object = { name: "Peter" }
```

This also works for all the other JSON builtin functions, including `json()`, `json_each()`, `json_tree()`, and more. Other SQLite extensions can also use the JSON subtype convention in their own custom functions. 

## Potentially backwards incompatible

Before, these functions would just return a string, and users would probably `JSON.parse()` it themselves. But now, it can possibly return arrays, objects, decoded JSON strings and numbers, etc. Because of that, I think merging this PR as-is would be a major version bump (well, minor since it's pre-v1)

However, we could also add a new database-level setting to make this new behavior opt-in. Maybe something like `db.enableJsonDeserializing(true)` or something in the constructor. Happy to include if you think it's best!