### PR TITLE
Add a `.sql` tagged template for executing one-off SQL queries

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -121,7 +121,9 @@ API.
 
 See [Binding Parameters](#binding-parameters) for more details.
 
-Alternatively, use the `.sql` tagged template to safely execute SQL with given parameters. It will execute the given SQL with parameters bounded and returns all rows, calling `.values()` under the hood.
+Alternatively, use the `.sql` tagged template to safely execute SQL with given
+parameters. It will execute the given SQL with parameters bounded and returns
+all rows with `.all()`.
 
 ```ts
 const minimum = 20;

--- a/doc.md
+++ b/doc.md
@@ -121,6 +121,21 @@ API.
 
 See [Binding Parameters](#binding-parameters) for more details.
 
+Alternatively, use the `.sql` tagged template to safely execute SQL with given parameters. It will execute the given SQL with parameters bounded and returns all rows, calling `.values()` under the hood.
+
+```ts
+const minimum = 20;
+const results = db.sql`
+  SELECT
+    id,
+    name,
+    age
+  FROM students
+  WHERE age > ${minimum}`;
+
+console.log(results); // [ [ 2, "Brian", 30 ] ]
+```
+
 ## Creating Prepared Statements
 
 To prepare a statement, use the `prepare()` method. This method will return a

--- a/src/database.ts
+++ b/src/database.ts
@@ -326,6 +326,16 @@ export class Database {
     return this.exec(sql, ...params);
   }
 
+  /** Safely execute SQL with parameters using a tagged template */
+  sql<T extends unknown[] = any[]>(
+    strings: TemplateStringsArray,
+    ...parameters: RestBindParameters
+  ): T[] {
+    const sql = strings.join("?");
+    const stmt = this.prepare(sql);
+    return stmt.values(...parameters);
+  }
+
   /**
    * Wraps a callback function in a transaction.
    *

--- a/src/database.ts
+++ b/src/database.ts
@@ -327,13 +327,13 @@ export class Database {
   }
 
   /** Safely execute SQL with parameters using a tagged template */
-  sql<T extends unknown[] = any[]>(
+  sql<T extends Record<string, unknown> = Record<string, any>>(
     strings: TemplateStringsArray,
     ...parameters: RestBindParameters
   ): T[] {
     const sql = strings.join("?");
     const stmt = this.prepare(sql);
-    return stmt.values(...parameters);
+    return stmt.all(...parameters);
   }
 
   /**

--- a/test/test.ts
+++ b/test/test.ts
@@ -236,12 +236,15 @@ Deno.test("sqlite", async (t) => {
   });
 
   await t.step(".sql tagged template", () => {
-    assertEquals(db.sql`select 1, 2, 3`, [[1, 2, 3]]);
-    assertEquals(db.sql`select ${1}, ${Math.PI}, ${new Uint8Array([1, 2])}`, [
-      [1, 3.141592653589793, new Uint8Array([1, 2])],
-    ]);
+    assertEquals(db.sql`select 1, 2, 3`, [{ "1": 1, "2": 2, "3": 3 }]);
+    assertEquals(
+      db.sql`select ${1} as a, ${Math.PI} as b, ${new Uint8Array([1, 2])} as c`,
+      [
+        { a: 1, b: 3.141592653589793, c: new Uint8Array([1, 2]) },
+      ],
+    );
 
-    assertEquals(db.sql`select ${"1; DROP TABLE"}`, [["1; DROP TABLE"]]);
+    assertEquals(db.sql`select ${"1; DROP TABLE"}`, [{ "?": "1; DROP TABLE" }]);
   });
 
   await t.step("more than 32-bit int", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -235,6 +235,15 @@ Deno.test("sqlite", async (t) => {
     assertEquals(row[4], '{"name":"alex"}');
   });
 
+  await t.step(".sql tagged template", () => {
+    assertEquals(db.sql`select 1, 2, 3`, [[1, 2, 3]]);
+    assertEquals(db.sql`select ${1}, ${Math.PI}, ${new Uint8Array([1, 2])}`, [
+      [1, 3.141592653589793, new Uint8Array([1, 2])],
+    ]);
+
+    assertEquals(db.sql`select ${"1; DROP TABLE"}`, [["1; DROP TABLE"]]);
+  });
+
   await t.step("more than 32-bit int", () => {
     const value = 978307200000;
     db.exec(


### PR DESCRIPTION
This PR adds a new `.sql` tagged template to the database class. It allows users to easily run one-off SQL queries with parameters bounded with a tagged templated. Parameters are safely encoded as `?` and bounded after the statement is prepared, meaning there's no possibility of SQL injection. 

```ts
db.sql`create table students(id, name)`;

const student = {id: 1, name: "Alex"};
db.sql`insert into students values (${student.id}, ${student.name})`;

db.sql`select * from students where id > ${0}`; // [ {"id": 1, "name": "Alex"} ]
```

The `.sql` tagged template returns all the rows returned by the query, calling `.all()` under the hood. 

The function is inspired by, and has a very similar API to these other libraries:

- Observable's DatabaseClient: https://observablehq.com/@observablehq/stdlib#cell-1749
- postgres.js: https://observablehq.com/@observablehq/stdlib#cell-1749
- Vercel postgres: https://vercel.com/docs/storage/vercel-postgres/sdk#sql