### PR TITLE
add: iter method to iterate with params

### DIFF
--- a/src/statement.ts
+++ b/src/statement.ts
@@ -763,8 +763,9 @@ export class Statement {
   }
 
   /** Iterate over resultant rows from query. */
-  *[Symbol.iterator](): IterableIterator<any> {
+  *iter(...params: RestBindParameters): IterableIterator<any> {
     this.#begin();
+    this.#bindAll(params);
     const getRowObject = this.getRowObject();
     let status;
     if (this.callback) {
@@ -784,6 +785,10 @@ export class Statement {
       unwrap(status, this.db.unsafeHandle);
     }
     sqlite3_reset(this.#handle);
+  }
+
+  [Symbol.iterator](): IterableIterator<any> {
+    return this.iter();
   }
 
   [Symbol.dispose](): void {


### PR DESCRIPTION
## Summary

- Add an `iter` method that accepts arguments to allow iterating through results. 
- Currently, there is no way to iterate providing args to bind to. 
- `Symbol[Iterator]` works for ones without any args.
- This PR exposes the method as `iter` that works both with and without bind values.

## Why

Without this, there's no way to iterate on large results efficiently. The current `all` methods and other variants always have to return the full query, which is not an ideal way to scan through the DB.  

## Alternative approaches

- The current `Symbol[iterator]` works for items without bind params, but any bind params will be reset on execution. Can just remove the resetting, but in that case, it breaks compatibility and older behavior, since it's the responsibility of the user of the prepared statement to ensure it's also reset and bound. 