### PR TITLE
Implemented stdext/sql interfaces

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,10 @@
   "version": "0.11.2",
   "github": "https://github.com/denodrivers/sqlite3",
 
-  "exports": "./mod.ts",
+  "exports": {
+    ".": "./mod.ts",
+    "./std_sql": "./std_sql.ts"
+  },
 
   "exclude": [
     "sqlite",
@@ -11,7 +14,8 @@
   ],
 
   "tasks": {
-    "test": "deno test --unstable-ffi -A test/test.ts",
+    "test": "DENO_SQLITE_LOCAL=1 deno test --unstable-ffi -A",
+    "test:remote": "deno test --unstable-ffi -A",
     "build": "deno run -A scripts/build.ts",
     "bench-deno": "deno run -A --unstable-ffi bench/bench_deno.js 50 1000000",
     "bench-deno-ffi": "deno run -A --unstable-ffi bench/bench_deno_ffi.js 50 1000000",
@@ -45,5 +49,14 @@
         "explicit-module-boundary-types"
       ]
     }
+  },
+
+  "imports": {
+    "@denosaurs/plug": "jsr:@denosaurs/plug@^1.0.5",
+    "@std/assert": "jsr:@std/assert@^0.221.0",
+    "@std/log": "jsr:@std/log@^0.223.0",
+    "@std/path": "jsr:@std/path@^0.217.0",
+    "@stdext/collections": "jsr:@stdext/collections@^0.0.5",
+    "@stdext/sql": "jsr:@stdext/sql@0.0.0-6"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,0 @@
-export { fromFileUrl } from "jsr:@std/path@0.217";
-export { dlopen } from "jsr:@denosaurs/plug@1";

--- a/mod.ts
+++ b/mod.ts
@@ -4,10 +4,9 @@ export {
   type DatabaseOpenOptions,
   type FunctionOptions,
   isComplete,
-  SQLITE_SOURCEID,
-  SQLITE_VERSION,
   type Transaction,
 } from "./src/database.ts";
+export { SQLITE_SOURCEID, SQLITE_VERSION } from "./src/ffi.ts";
 export { type BlobOpenOptions, SQLBlob } from "./src/blob.ts";
 export {
   type BindParameters,

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -1,6 +1,6 @@
 import type { Database } from "./database.ts";
-import ffi from "./ffi.ts";
-import { toCString, unwrap } from "./util.ts";
+import ffi, { unwrap } from "./ffi.ts";
+import { toCString } from "./util.ts";
 
 const {
   sqlite3_blob_open,

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -1,0 +1,28 @@
+import { assert, assertEquals } from "@std/assert";
+import { SqliteConnectable, SqliteConnection } from "./connection.ts";
+import { _testSqlConnectable, testSqlConnection } from "@stdext/sql/testing";
+
+Deno.test("connection and connectable contstructs", () => {
+  const connection = new SqliteConnection(":memory:");
+  testSqlConnection(connection, { connectionUrl: ":memory:" });
+  const connectable = new SqliteConnectable(connection);
+  _testSqlConnectable(connectable, connection);
+});
+
+Deno.test("connection can connect and query", async () => {
+  await using connection = new SqliteConnection(":memory:");
+  await connection.connect();
+  assert(connection.connected, "connection should be connected");
+  const executeResult = await connection.execute(`select 1 as one`);
+  assertEquals(executeResult, 0);
+  const queryManyResult = connection.queryMany(`select 1 as one`);
+  const queryManyResultNext1 = await queryManyResult.next();
+  assertEquals(queryManyResultNext1, { done: false, value: { one: 1 } });
+  const queryManyResultNext2 = await queryManyResult.next();
+  assertEquals(queryManyResultNext2, { done: true, value: undefined });
+  const queryManyArrayResult = connection.queryManyArray(`select 1 as one`);
+  const queryManyArrayResultNext1 = await queryManyArrayResult.next();
+  assertEquals(queryManyArrayResultNext1, { done: false, value: [1] });
+  const queryManyArrayResultNext2 = await queryManyArrayResult.next();
+  assertEquals(queryManyArrayResultNext2, { done: true, value: undefined });
+});

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,0 +1,144 @@
+// deno-lint-ignore-file require-await
+import type {
+  ArrayRow,
+  Row,
+  SqlConnectable,
+  SqlConnection,
+  SqlConnectionOptions,
+} from "@stdext/sql";
+import { fromFileUrl } from "@std/path";
+import ffi from "./ffi.ts";
+import { Database, type DatabaseOpenOptions } from "../mod.ts";
+import type { SqliteParameterType, SqliteQueryOptions } from "./core.ts";
+import { transformToAsyncGenerator } from "./util.ts";
+
+/** Various options that can be configured when opening Database connection. */
+export interface SqliteConnectionOptions
+  extends SqlConnectionOptions, DatabaseOpenOptions {
+}
+
+/**
+ * Represents a SQLx based SQLite3 database connection.
+ *
+ * Example:
+ * ```ts
+ * // Open a database from file, creates if doesn't exist.
+ * const db = new SqliteClient("myfile.db");
+ *
+ * // Open an in-memory database.
+ * const db = new SqliteClient(":memory:");
+ *
+ * // Open a read-only database.
+ * const db = new SqliteClient("myfile.db", { readonly: true });
+ *
+ * // Or open using File URL
+ * const db = new SqliteClient(new URL("./myfile.db", import.meta.url));
+ * ```
+ */
+export class SqliteConnection implements
+  SqlConnection<
+    SqliteConnectionOptions,
+    SqliteParameterType,
+    SqliteQueryOptions
+  > {
+  readonly connectionUrl: string;
+  readonly options: SqliteConnectionOptions;
+
+  /**
+   * The FFI SQLite methods.
+   */
+  readonly ffi = ffi;
+
+  _db: Database | null = null;
+
+  get db(): Database {
+    if (this._db === null) {
+      throw new Error("Database connection is not open");
+    }
+    return this._db;
+  }
+
+  set db(value: Database | null) {
+    this._db = value;
+  }
+
+  get connected(): boolean {
+    return Boolean(this._db?.open);
+  }
+
+  constructor(
+    connectionUrl: string | URL,
+    options: SqliteConnectionOptions = {},
+  ) {
+    this.connectionUrl = connectionUrl instanceof URL
+      ? fromFileUrl(connectionUrl)
+      : connectionUrl;
+    this.options = options;
+  }
+
+  async connect(): Promise<void> {
+    this.db = new Database(this.connectionUrl, this.options);
+  }
+
+  async close(): Promise<void> {
+    this._db?.close();
+    this._db = null;
+  }
+
+  execute(
+    sql: string,
+    params?: SqliteParameterType[],
+    _options?: SqliteQueryOptions,
+  ): Promise<number | undefined> {
+    return Promise.resolve(this.db.exec(sql, ...(params || [])));
+  }
+  queryMany<T extends Row<any> = Row<any>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions,
+  ): AsyncGenerator<T, any, unknown> {
+    return transformToAsyncGenerator(
+      this.db.prepare(sql).getMany<T>(params, options),
+    );
+  }
+  queryManyArray<T extends ArrayRow<any> = ArrayRow<any>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions,
+  ): AsyncGenerator<T, any, unknown> {
+    return transformToAsyncGenerator(
+      this.db.prepare(sql).valueMany<T>(params, options),
+    );
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
+  [Symbol.for("Deno.customInspect")](): string {
+    return `SQLite3.SqliteConnection { path: ${this.connectionUrl} }`;
+  }
+}
+
+export class SqliteConnectable implements
+  SqlConnectable<
+    SqliteConnectionOptions,
+    SqliteConnection
+  > {
+  readonly connection: SqliteConnection;
+  readonly options: SqliteConnectionOptions;
+  get connected(): boolean {
+    return this.connection.connected;
+  }
+
+  constructor(
+    connection: SqliteConnectable["connection"],
+    options: SqliteConnectable["options"] = {},
+  ) {
+    this.connection = connection;
+    this.options = options;
+  }
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.connection.close();
+  }
+}

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -1,0 +1,294 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { SQLITE_VERSION } from "./ffi.ts";
+import {
+  SqliteClient,
+  type SqliteParameterType,
+  SqlitePreparedStatement,
+  SqliteTransaction,
+} from "./core.ts";
+import {
+  testClientConnection,
+  testSqlClient,
+  testSqlPreparedStatement,
+  testSqlTransaction,
+} from "@stdext/sql/testing";
+import { SqliteError } from "./util.ts";
+import { SqliteConnection } from "./connection.ts";
+
+Deno.test("std/sql prepared statement", async () => {
+  const connectionUrl = ":memory:";
+  const options: SqliteTransaction["options"] = {};
+  const sql = "SELECT 1 as one;";
+
+  const connection = new SqliteConnection(connectionUrl, options);
+  await connection.connect();
+  const preparedStatement = new SqlitePreparedStatement(
+    connection,
+    sql,
+    options,
+  );
+  testSqlPreparedStatement(preparedStatement, {
+    connectionUrl,
+    options,
+    sql,
+  });
+});
+
+Deno.test("std/sql transaction", async () => {
+  const connectionUrl = ":memory:";
+  const options: SqliteTransaction["options"] = {};
+
+  const connection = new SqliteConnection(connectionUrl, options);
+  await connection.connect();
+  const transaction = new SqliteTransaction(connection, options);
+
+  testSqlTransaction(transaction, {
+    connectionUrl,
+    options,
+  });
+});
+
+Deno.test("std/sql client", async (t) => {
+  const connectionUrl = ":memory:";
+  const options: SqliteClient["options"] = {};
+
+  const client = new SqliteClient(connectionUrl, options);
+
+  testSqlClient(client, { connectionUrl, options });
+  await testClientConnection(
+    t,
+    SqliteClient,
+    [
+      connectionUrl,
+      options,
+    ],
+  );
+});
+
+Deno.test("std/sql queries", async (t) => {
+  const DB_URL = new URL("./test.db", import.meta.url);
+
+  // Remove any existing test.db.
+  await Deno.remove(DB_URL).catch(() => {});
+
+  await t.step("open (expect error)", async () => {
+    const db = new SqliteClient(DB_URL, { create: false });
+    await assertRejects(
+      async () => await db.connect(),
+      SqliteError,
+      "14:",
+    );
+  });
+
+  await t.step("open (path string)", async () => {
+    const db = new SqliteClient("test-path.db");
+    await db.connect();
+    await db.close();
+    Deno.removeSync("test-path.db");
+  });
+
+  await t.step("open (readonly)", async () => {
+    const db = new SqliteClient(":memory:", { readonly: true });
+    await db.connect();
+    await db.close();
+  });
+
+  let db!: SqliteClient;
+  await t.step("open (url)", async () => {
+    db = new SqliteClient(DB_URL, { int64: true });
+    await db.connect();
+  });
+
+  if (typeof db !== "object") throw new Error("db open failed");
+
+  await t.step("execute pragma", async () => {
+    await db.execute("pragma journal_mode = WAL");
+    await db.execute("pragma synchronous = normal");
+    assertEquals(await db.execute("pragma temp_store = memory"), 0);
+  });
+
+  await t.step("select version (row as array)", async () => {
+    const row = await db.queryOneArray<[string]>("select sqlite_version()");
+    assertEquals(row, [SQLITE_VERSION]);
+  });
+
+  await t.step("select version (row as object)", async () => {
+    const row = await db.queryOne<
+      { version: string }
+    >("select sqlite_version() as version");
+    assertEquals(row, { version: SQLITE_VERSION });
+  });
+
+  await t.step("create table", async () => {
+    await db.execute(`create table test (
+      integer integer,
+      text text not null,
+      double double,
+      blob blob not null,
+      nullable integer
+    )`);
+  });
+
+  await t.step("insert one", async () => {
+    const changes = await db.execute(
+      `insert into test (integer, text, double, blob, nullable)
+      values (?, ?, ?, ?, ?)`,
+      [
+        0,
+        "hello world",
+        3.14,
+        new Uint8Array([1, 2, 3]),
+        null,
+      ],
+    );
+
+    assertEquals(changes, 1);
+  });
+
+  await t.step("delete inserted row", async () => {
+    await db.execute("delete from test where integer = 0");
+  });
+
+  await t.step("last insert row id (after insert)", () => {
+    assertEquals(db.connection.db.lastInsertRowId, 1);
+  });
+
+  await t.step("prepared insert", async () => {
+    const SQL = `insert into test (integer, text, double, blob, nullable)
+    values (?, ?, ?, ?, ?)`;
+
+    const rows: SqliteParameterType[][] = [];
+    for (let i = 0; i < 10; i++) {
+      rows.push([
+        i,
+        `hello ${i}`,
+        3.14,
+        new Uint8Array([3, 2, 1]),
+        null,
+      ]);
+    }
+
+    let changes = 0;
+    await db.transaction(async (t) => {
+      for (const row of rows) {
+        changes += await t.execute(SQL, row) ?? 0;
+      }
+    });
+
+    assertEquals(changes, 10);
+  });
+
+  await t.step("query array", async () => {
+    const rows = await db.queryArray<
+      [number, string, number, Uint8Array, null]
+    >("select * from test where integer = 0 limit 1");
+
+    assertEquals(rows.length, 1);
+    const row = rows[0];
+    assertEquals(row[0], 0);
+    assertEquals(row[1], "hello 0");
+    assertEquals(row[2], 3.14);
+    assertEquals(row[3], new Uint8Array([3, 2, 1]));
+    assertEquals(row[4], null);
+  });
+
+  await t.step("query object", async () => {
+    const rows = await db.query<{
+      integer: number;
+      text: string;
+      double: number;
+      blob: Uint8Array;
+      nullable: null;
+    }>(
+      "select * from test where integer != ? and text != ?",
+      [
+        1,
+        "hello world",
+      ],
+    );
+
+    assertEquals(rows.length, 9);
+    for (const row of rows) {
+      assertEquals(typeof row.integer, "number");
+      assertEquals(row.text, `hello ${row.integer}`);
+      assertEquals(row.double, 3.14);
+      assertEquals(row.blob, new Uint8Array([3, 2, 1]));
+      assertEquals(row.nullable, null);
+    }
+  });
+
+  await t.step("query array (iter)", async () => {
+    const rows = [];
+    for await (
+      const row of await db.queryManyArray<
+        [number, string, number, Uint8Array, null]
+      >("select * from test where integer = ? limit 1", [0])
+    ) {
+      rows.push(row);
+    }
+
+    assertEquals(rows.length, 1);
+
+    const row = rows[0];
+    assertEquals(row[0], 0);
+    assertEquals(row[1], "hello 0");
+    assertEquals(row[2], 3.14);
+    assertEquals(row[3], new Uint8Array([3, 2, 1]));
+    assertEquals(row[4], null);
+  });
+
+  await t.step("query object (iter)", async () => {
+    const rows = [];
+    for await (
+      const row of db.queryMany<{
+        integer: number;
+        text: string;
+        double: number;
+        blob: Uint8Array;
+        nullable: null;
+      }>("select * from test where integer != ? and text != ?", [
+        1,
+        "hello world",
+      ])
+    ) {
+      rows.push(row);
+    }
+
+    assertEquals(rows.length, 9);
+    for (const row of rows) {
+      assertEquals(typeof row.integer, "number");
+      assertEquals(row.text, `hello ${row.integer}`);
+      assertEquals(row.double, 3.14);
+      assertEquals(row.blob, new Uint8Array([3, 2, 1]));
+      assertEquals(row.nullable, null);
+    }
+  });
+
+  await t.step("tagged template object", async () => {
+    assertEquals(await db.sql`select 1, 2, 3`, [{ "1": 1, "2": 2, "3": 3 }]);
+    assertEquals(
+      await db.sql`select ${1} as a, ${Math.PI} as b, ${new Uint8Array([
+        1,
+        2,
+      ])} as c`,
+      [
+        { a: 1, b: 3.141592653589793, c: new Uint8Array([1, 2]) },
+      ],
+    );
+
+    assertEquals(await db.sql`select ${"1; DROP TABLE"}`, [{
+      "?": "1; DROP TABLE",
+    }]);
+  });
+
+  await t.step({
+    name: "close",
+    sanitizeResources: false,
+    fn(): void {
+      db.close();
+      try {
+        Deno.removeSync(DB_URL);
+      } catch (_) { /** ignore, already being used */ }
+    },
+  });
+});

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,391 @@
+import type {
+  ArrayRow,
+  Row,
+  SqlClient,
+  SqlConnectionOptions,
+  SqlPreparable,
+  SqlPreparedStatement,
+  SqlQueriable,
+  SqlQueryOptions,
+  SqlTransaction,
+  SqlTransactionable,
+  SqlTransactionOptions,
+} from "@stdext/sql";
+import {
+  type BindValue,
+  Statement,
+  type StatementOptions,
+} from "./statement.ts";
+import type { DatabaseOpenOptions } from "../mod.ts";
+import {
+  SqliteCloseEvent,
+  SqliteConnectEvent,
+  SqliteEventTarget,
+} from "./events.ts";
+import {
+  SqliteConnectable,
+  SqliteConnection,
+  type SqliteConnectionOptions,
+} from "./connection.ts";
+import { SqliteTransactionError } from "./errors.ts";
+import { mergeQueryOptions, transformToAsyncGenerator } from "./util.ts";
+
+export type SqliteParameterType = BindValue;
+
+export interface SqliteQueryOptions extends SqlQueryOptions, StatementOptions {
+}
+
+export interface SqliteTransactionOptions extends SqlTransactionOptions {
+  beginTransactionOptions: {
+    behavior?: "DEFERRED" | "IMMEDIATE" | "EXCLUSIVE";
+  };
+  commitTransactionOptions: undefined;
+  rollbackTransactionOptions: {
+    savepoint?: string;
+  };
+}
+
+/** Various options that can be configured when opening Database connection. */
+export interface SqliteClientOptions
+  extends SqlConnectionOptions, DatabaseOpenOptions {
+}
+
+export class SqlitePreparedStatement extends SqliteConnectable
+  implements
+    SqlPreparedStatement<
+      SqliteConnectionOptions,
+      SqliteParameterType,
+      SqliteQueryOptions,
+      SqliteConnection
+    > {
+  readonly sql: string;
+  declare readonly options: SqliteConnectionOptions & SqliteQueryOptions;
+  readonly #statement: Statement;
+  #deallocated = false;
+
+  constructor(
+    connection: SqlitePreparedStatement["connection"],
+    sql: string,
+    options: SqlitePreparedStatement["options"] = {},
+  ) {
+    super(connection, options);
+    this.sql = sql;
+
+    this.#statement = new Statement(
+      this.connection.db.unsafeHandle,
+      this.sql,
+      this.options,
+    );
+  }
+  get deallocated(): boolean {
+    return this.#deallocated;
+  }
+
+  deallocate(): Promise<void> {
+    this.#statement.finalize();
+    this.#deallocated = true;
+    return Promise.resolve();
+  }
+
+  execute(
+    params?: SqliteParameterType[],
+    _options?: SqliteQueryOptions | undefined,
+  ): Promise<number | undefined> {
+    return Promise.resolve(this.#statement.run(params));
+  }
+  query<T extends Row<BindValue> = Row<BindValue>>(
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T[]> {
+    return Promise.resolve(this.#statement.all<T>(params, options));
+  }
+  queryOne<T extends Row<BindValue> = Row<BindValue>>(
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T | undefined> {
+    return Promise.resolve(this.#statement.get<T>(params, options));
+  }
+  queryMany<T extends Row<BindValue> = Row<BindValue>>(
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): AsyncGenerator<T> {
+    return transformToAsyncGenerator(
+      this.#statement.getMany<T>(params, options),
+    );
+  }
+  queryArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T[]> {
+    return Promise.resolve(this.#statement.values<T>(params, options));
+  }
+  queryOneArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T | undefined> {
+    return Promise.resolve(this.#statement.value<T>(params, options));
+  }
+  queryManyArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): AsyncGenerator<T> {
+    return transformToAsyncGenerator(
+      this.#statement.valueMany<T>(params, options),
+    );
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.deallocate();
+    await super[Symbol.asyncDispose]();
+  }
+}
+
+/**
+ * Represents a base queriable class for SQLite3.
+ */
+export class SqliteQueriable extends SqliteConnectable implements
+  SqlQueriable<
+    SqliteConnectionOptions,
+    SqliteParameterType,
+    SqliteQueryOptions,
+    SqliteConnection
+  > {
+  declare readonly options: SqliteConnectionOptions & SqliteQueryOptions;
+
+  constructor(
+    connection: SqliteQueriable["connection"],
+    options: SqliteQueriable["options"] = {},
+  ) {
+    super(connection, options);
+  }
+  prepare(sql: string, options?: SqliteQueryOptions): SqlitePreparedStatement {
+    return new SqlitePreparedStatement(
+      this.connection,
+      sql,
+      mergeQueryOptions(this.options, options),
+    );
+  }
+
+  execute(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<number | undefined> {
+    return this.prepare(sql, options).execute(params);
+  }
+  query<T extends Row<BindValue> = Row<BindValue>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T[]> {
+    return this.prepare(sql, options).query<T>(params);
+  }
+  queryOne<T extends Row<BindValue> = Row<BindValue>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T | undefined> {
+    return this.prepare(sql, options).queryOne<T>(params);
+  }
+  queryMany<T extends Row<BindValue> = Row<BindValue>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): AsyncGenerator<T> {
+    return this.prepare(sql, options).queryMany<T>(params);
+  }
+  queryArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T[]> {
+    return this.prepare(sql, options).queryArray<T>(params);
+  }
+  queryOneArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): Promise<T | undefined> {
+    return this.prepare(sql, options).queryOneArray<T>(params);
+  }
+  queryManyArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    sql: string,
+    params?: SqliteParameterType[],
+    options?: SqliteQueryOptions | undefined,
+  ): AsyncGenerator<T> {
+    return this.connection.queryManyArray<T>(sql, params, options);
+  }
+
+  sql<T extends Row<BindValue> = Row<BindValue>>(
+    strings: TemplateStringsArray,
+    ...parameters: BindValue[]
+  ): Promise<T[]> {
+    const sql = strings.join("?");
+    return this.query<T>(sql, parameters);
+  }
+
+  sqlArray<T extends ArrayRow<BindValue> = ArrayRow<BindValue>>(
+    strings: TemplateStringsArray,
+    ...parameters: BindValue[]
+  ): Promise<T[]> {
+    const sql = strings.join("?");
+    return this.queryArray<T>(sql, parameters);
+  }
+}
+
+export class SqlitePreparable extends SqliteQueriable implements
+  SqlPreparable<
+    SqliteConnectionOptions,
+    SqliteParameterType,
+    SqliteQueryOptions,
+    SqliteConnection,
+    SqlitePreparedStatement
+  > {
+}
+
+export class SqliteTransaction extends SqliteQueriable
+  implements
+    SqlTransaction<
+      SqliteConnectionOptions,
+      SqliteParameterType,
+      SqliteQueryOptions,
+      SqliteConnection,
+      SqlitePreparedStatement,
+      SqliteTransactionOptions
+    > {
+  #inTransaction: boolean = true;
+  get inTransaction(): boolean {
+    return this.connected && this.#inTransaction;
+  }
+
+  get connected(): boolean {
+    if (!this.#inTransaction) {
+      throw new SqliteTransactionError(
+        "Transaction is not active, create a new one using beginTransaction",
+      );
+    }
+
+    return super.connected;
+  }
+
+  async commitTransaction(
+    _options?: SqliteTransactionOptions["commitTransactionOptions"],
+  ): Promise<void> {
+    try {
+      await this.execute("COMMIT");
+    } catch (e) {
+      this.#inTransaction = false;
+      throw e;
+    }
+  }
+  async rollbackTransaction(
+    options?: SqliteTransactionOptions["rollbackTransactionOptions"],
+  ): Promise<void> {
+    try {
+      if (options?.savepoint) {
+        await this.execute("ROLLBACK TO ?", [options.savepoint]);
+      } else {
+        await this.execute("ROLLBACK");
+      }
+    } catch (e) {
+      this.#inTransaction = false;
+      throw e;
+    }
+  }
+  async createSavepoint(name: string = `\t_bs3.\t`): Promise<void> {
+    await this.execute(`SAVEPOINT ${name}`);
+  }
+  async releaseSavepoint(name: string = `\t_bs3.\t`): Promise<void> {
+    await this.execute(`RELEASE ${name}`);
+  }
+}
+
+/**
+ * Represents a queriable class that can be used to run transactions.
+ */
+export class SqliteTransactionable extends SqlitePreparable
+  implements
+    SqlTransactionable<
+      SqliteConnectionOptions,
+      SqliteParameterType,
+      SqliteQueryOptions,
+      SqliteConnection,
+      SqlitePreparedStatement,
+      SqliteTransactionOptions,
+      SqliteTransaction
+    > {
+  async beginTransaction(
+    options?: SqliteTransactionOptions["beginTransactionOptions"],
+  ): Promise<SqliteTransaction> {
+    let sql = "BEGIN";
+    if (options?.behavior) {
+      sql += ` ${options.behavior}`;
+    }
+    await this.execute(sql);
+
+    return new SqliteTransaction(this.connection, this.options);
+  }
+
+  async transaction<T>(
+    fn: (t: SqliteTransaction) => Promise<T>,
+    options?: SqliteTransactionOptions,
+  ): Promise<T> {
+    const transaction = await this.beginTransaction(
+      options?.beginTransactionOptions,
+    );
+
+    try {
+      const result = await fn(transaction);
+      await transaction.commitTransaction(options?.commitTransactionOptions);
+      return result;
+    } catch (error) {
+      await transaction.rollbackTransaction(
+        options?.rollbackTransactionOptions,
+      );
+      throw error;
+    }
+  }
+}
+
+/**
+ * Sqlite client
+ */
+export class SqliteClient extends SqliteTransactionable implements
+  SqlClient<
+    SqliteEventTarget,
+    SqliteConnectionOptions,
+    SqliteParameterType,
+    SqliteQueryOptions,
+    SqliteConnection,
+    SqlitePreparedStatement,
+    SqliteTransactionOptions,
+    SqliteTransaction
+  > {
+  readonly eventTarget: SqliteEventTarget;
+
+  constructor(
+    connectionUrl: string | URL,
+    options: SqliteClientOptions = {},
+  ) {
+    const conn = new SqliteConnection(connectionUrl, options);
+    super(conn, options);
+    this.eventTarget = new SqliteEventTarget();
+  }
+
+  async connect(): Promise<void> {
+    await this.connection.connect();
+    this.eventTarget.dispatchEvent(
+      new SqliteConnectEvent({ connection: this.connection }),
+    );
+  }
+  async close(): Promise<void> {
+    this.eventTarget.dispatchEvent(
+      new SqliteCloseEvent({ connection: this.connection }),
+    );
+    await this.connection.close();
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,20 @@
+import { isSqlError, SqlError } from "@stdext/sql";
+
+export class SqliteError extends SqlError {
+  constructor(msg: string) {
+    super(msg);
+  }
+}
+
+export class SqliteTransactionError extends SqliteError {
+  constructor(msg: string) {
+    super(msg);
+  }
+}
+
+/**
+ * Check if an error is a SqliteError
+ */
+export function isSqliteError(err: unknown): err is SqliteError {
+  return isSqlError(err) && err instanceof SqliteError;
+}

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,0 +1,6 @@
+import { SqliteEventTarget } from "./events.ts";
+import { testSqlEventTarget } from "@stdext/sql/testing";
+
+Deno.test("event constructs", () => {
+  testSqlEventTarget(new SqliteEventTarget());
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,33 @@
+import {
+  type SqlClientEventType,
+  SqlCloseEvent,
+  SqlConnectEvent,
+  type SqlConnectionEventInit,
+  SqlEventTarget,
+} from "@stdext/sql";
+import type {
+  SqliteConnection,
+  SqliteConnectionOptions,
+} from "./connection.ts";
+
+export class SqliteEventTarget extends SqlEventTarget<
+  SqliteConnectionOptions,
+  SqliteConnection,
+  SqlClientEventType,
+  SqliteConnectionEventInit,
+  SqliteEvents
+> {
+}
+
+export type SqliteConnectionEventInit = SqlConnectionEventInit<
+  SqliteConnection
+>;
+
+export class SqliteConnectEvent
+  extends SqlConnectEvent<SqliteConnectionEventInit> {}
+export class SqliteCloseEvent
+  extends SqlCloseEvent<SqliteConnectionEventInit> {}
+
+export type SqliteEvents =
+  | SqliteConnectEvent
+  | SqliteCloseEvent;

--- a/std_sql.ts
+++ b/std_sql.ts
@@ -1,0 +1,13 @@
+export * from "./src/core.ts";
+export * from "./src/connection.ts";
+export * from "./src/errors.ts";
+export * from "./src/events.ts";
+
+export { type BlobOpenOptions, SQLBlob } from "./src/blob.ts";
+export {
+  type BindParameters,
+  type BindValue,
+  Statement,
+} from "./src/statement.ts";
+export { SqliteError } from "./src/util.ts";
+export { SQLITE_SOURCEID, SQLITE_VERSION } from "./src/ffi.ts";

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,1 +1,0 @@
-export * from "https://deno.land/std@0.179.0/testing/asserts.ts";

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,7 +5,7 @@ import {
   SQLITE_VERSION,
   SqliteError,
 } from "../mod.ts";
-import { assert, assertEquals, assertThrows } from "./deps.ts";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 
 console.log("sqlite version:", SQLITE_VERSION);
 
@@ -167,10 +167,10 @@ Deno.test("sqlite", async (t) => {
         double: number;
         blob: Uint8Array;
         nullable: null;
-      }>(
+      }>([
         1,
         "hello world",
-      );
+      ]);
 
     assertEquals(rows.length, 9);
     for (const row of rows) {
@@ -197,7 +197,7 @@ Deno.test("sqlite", async (t) => {
   await t.step("query with string param", () => {
     const row = db.prepare(
       "select * from test where text = ?",
-    ).values<[number, string, number, Uint8Array, null]>("hello 0")[0];
+    ).values<[number, string, number, Uint8Array, null]>(["hello 0"])[0];
 
     assertEquals(row[0], 0);
     assertEquals(row[1], "hello 0");
@@ -220,13 +220,13 @@ Deno.test("sqlite", async (t) => {
   await t.step("query parameters", () => {
     const row = db.prepare(
       "select ?, ?, ?, ?, ?",
-    ).values<[number, string, string, string, string]>(
+    ).values<[number, string, string, string, string]>([
       1,
       "alex",
       new Date("2023-01-01"),
       [1, 2, 3],
       { name: "alex" },
-    )[0];
+    ])[0];
 
     assertEquals(row[0], 1);
     assertEquals(row[1], "alex");
@@ -260,7 +260,7 @@ Deno.test("sqlite", async (t) => {
     );
     const [int] = db.prepare(
       "select integer from test where text = ?",
-    ).values<[number]>("bigint")[0];
+    ).values<[number]>(["bigint"], { int64: true })[0];
     assertEquals(int, value);
   });
 
@@ -277,7 +277,7 @@ Deno.test("sqlite", async (t) => {
     );
     const [int] = db.prepare(
       "select integer from test where text = ?",
-    ).values<[number]>("bigint2")[0];
+    ).values<[number]>(["bigint2"], { int64: true })[0];
     assertEquals(int, value);
   });
 
@@ -294,7 +294,7 @@ Deno.test("sqlite", async (t) => {
     );
     const [int] = db.prepare(
       "select integer from test where text = ?",
-    ).values<[bigint]>("bigint3")[0];
+    ).values<[bigint]>(["bigint3"], { int64: true })[0];
     assertEquals(int, value);
   });
 
@@ -310,7 +310,7 @@ Deno.test("sqlite", async (t) => {
     );
     const [int, double] = db.prepare(
       "select integer, double from test where text = ?",
-    ).values<[number, number]>("nan")[0];
+    ).values<[number, number]>(["nan"])[0];
     assertEquals(int, null);
     assertEquals(double, null);
   });
@@ -462,37 +462,37 @@ Deno.test("sqlite", async (t) => {
     const [result] = db
       .prepare("select deno_add(?, ?)")
       .enableCallback()
-      .value<[number]>(1, 2)!;
+      .value<[number]>([1, 2])!;
     assertEquals(result, 3);
 
     const [result2] = db
       .prepare("select deno_uppercase(?)")
       .enableCallback()
-      .value<[string]>("hello")!;
+      .value<[string]>(["hello"])!;
     assertEquals(result2, "HELLO");
 
     const [result3] = db
       .prepare("select deno_buffer_add_1(?)")
       .enableCallback()
-      .value<[Uint8Array]>(new Uint8Array([1, 2, 3]))!;
+      .value<[Uint8Array]>([new Uint8Array([1, 2, 3])])!;
     assertEquals(result3, new Uint8Array([2, 3, 4]));
 
-    const [result4] = db.prepare("select deno_add(?, ?)").value<[number]>(
+    const [result4] = db.prepare("select deno_add(?, ?)").value<[number]>([
       1.5,
       1.5,
-    )!;
+    ])!;
     assertEquals(result4, 3);
 
     const [result5] = db
       .prepare("select regexp(?, ?)")
       .enableCallback()
-      .value<[number]>("hello", "h.*")!;
+      .value<[number]>(["hello", "h.*"])!;
     assertEquals(result5, 1);
 
     const [result6] = db
       .prepare("select regexp(?, ?)")
       .enableCallback()
-      .value<[number]>("hello", "x.*")!;
+      .value<[number]>(["hello", "x.*"])!;
     assertEquals(result6, 0);
 
     db.exec("create table aggr_test (value integer)");


### PR DESCRIPTION
Had to open another PR due to a rebase issue on my part.

Relates to https://github.com/denodrivers/sqlite3/issues/123

This PR introduces some breaking changes to the Statement class. The Database class is not altered in a breaking way, and a new entrypoint has been introduced.

Changes:

- Breaking change in statement class
- Moved all deps to deno.json as import map
- Added bench for stdext/sql
- Added iterator for array result
- Moved some code around
- Added tests