### PR TITLE
fix: update type generic to allow interfaces

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -344,7 +344,7 @@ export class Database {
   }
 
   /** Safely execute SQL with parameters using a tagged template */
-  sql<T extends Record<string, unknown> = Record<string, any>>(
+  sql<T extends Record<string, any> = Record<string, any>>(
     strings: TemplateStringsArray,
     ...parameters: RestBindParameters
   ): T[] {


### PR DESCRIPTION
The definition of the type-generic used on the `sql()` function is:

```ts
sql<T extends Record<string, unknown> = Record<string, any>>
```

The `Record<string, unknown>` is an alias for the `{ [key: string]: unknown }` type signature.  The problem is that `interface` definitions don't include this type signature, so they cannot be passed into this type-generic.

Here's a standalone example:

```ts
interface MyInterface {
  name: string
}

const myFunc = <T extends Record<string, unknown> = Record<string, any>>(
  param: T,
) => undefined

const myInterface: MyInterface = {
  name: 'Name',
}

myFunc<MyInterface>(myInterface)
```

This will produce a type-check error:

> Type 'MyInterface' does not satisfy the constraint 'Record<string, unknown>'.
  Index signature for type 'string' is missing in type 'MyInterface'. [2344]