### PR TITLE
Making statements generic

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -276,8 +276,8 @@ export class Database {
    * @param sql SQL statement string
    * @returns Statement object
    */
-  prepare(sql: string): Statement {
-    return new Statement(this, sql);
+  prepare<T extends object = Record<string, any>>(sql: string): Statement<T> {
+    return new Statement<T>(this, sql);
   }
 
   /**

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -135,7 +135,7 @@ function getColumn(handle: Deno.PointerValue, i: number, int64: boolean): any {
  *
  * See `Database#prepare` for more information.
  */
-export class Statement {
+export class Statement<TStatement extends object = Record<string, any>> {
   #handle: Deno.PointerValue;
   #finalizerToken: { handle: Deno.PointerValue };
   #bound = false;
@@ -188,7 +188,7 @@ export class Statement {
    * Run the query and return the resulting rows where rows are objects
    * mapping column name to their corresponding values.
    */
-  all<T extends object = Record<string, any>>(
+  all<T extends object = TStatement>(
     ...args: RestBindParameters
   ): T[] {
     return this.#allWithArgs(...args);
@@ -626,7 +626,7 @@ export class Statement {
   }
 
   /** Fetch only first row as an object, if any. */
-  get<T extends object>(
+  get<T extends object = TStatement>(
     ...params: RestBindParameters
   ): T | undefined {
     const handle = this.#handle;


### PR DESCRIPTION
Currently some statement methods support generics for type hinting the result of the query, for example:
```ts
all<T extends object = Record<string, any>>(...args: RestBindParameters): T[]
get<T extends object>(...params: RestBindParameters): T | undefined
```

In a lot of cases the generic used is the same between these two methods because the same query was used to prepare the statement

I propose adding a generic type to statement itself that would allow to both of these methods to be typed automatically

This is the proposed usage
```ts
interface UserTable {
  name: string;
  email: string;
}
const statement = new Database().prepare<UserTable>("SELECT name, email FROM users");

const singleUser: UserTable | undefined = statement.get();
const allUsers: UserTable[] = statement.all();
```

This would lay the groundwork for typing the iterator in the future so it could be used like so:
```
for (const row of statement) {
  const user: UserTable = row;
}
```

What remains unsolved is typing of `value` and `values` methods, I propose leaving them as is for simplifying the API/proposal